### PR TITLE
Update UpdateChecker.kt: Add delay to reduce 429 Too Many Requests.

### DIFF
--- a/app/src/main/kotlin/client/UpdateChecker.kt
+++ b/app/src/main/kotlin/client/UpdateChecker.kt
@@ -50,6 +50,8 @@ class UpdateChecker(private val context: Context) {
                 if (!updateChecker.shouldCheck(install))
                     continue
 
+                delay(1000)
+
                 launch(Dispatchers.IO) {
                     var result: UpdateCheckResult
                     val game: Game = if (gameCache.containsKey(install.gameId)) {


### PR DESCRIPTION
This might be a hacky way, but I'd really like a delay in updates if it means my whole library actually gets updated.

Hi, first off, I want to say I really like your app. I've added a delay between update calls to reduce the amount of 429 "Too Many Requests" errors.
I tested this a bit on an emulator with around 18 games installed and refreshing. And it had a good result, I got no 429's. While without the delay, I'd get around 3 or more. However, this amount only increases further the more games you have downloaded.