### PR TITLE
feat: themed icon for Android 13 and above

### DIFF
--- a/app/src/main/res/drawable-v33/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable-v33/ic_launcher_monochrome.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="108"
+        android:viewportHeight="108">
+    <group android:scaleX="3.7795277"
+            android:scaleY="3.7795277">
+        <path
+                android:pathData="m11.8553,12.8141 l2.4322,2.4321 2.4322,-2.4321 3.0402,6.0804L16.7197,18.8945l-1.2161,-1.2161 -1.2161,1.2161 -1.2161,-1.2161 -1.2161,1.2161l-3.0402,0z"
+                android:strokeWidth="0.264583"
+                android:fillColor="#ffffff"
+                android:strokeColor="#00000000"/>
+        <path
+                android:pathData="m14.2875,13.7854 l-2.8376,-2.8376h1.7026V6.9753h2.2701v3.9726h1.7026z"
+                android:strokeLineJoin="miter"
+                android:strokeWidth="0.567512"
+                android:fillColor="#ffffff"
+                android:strokeColor="#00000000"
+                android:strokeLineCap="butt"/>
+    </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds the [Themed Icon feature](https://www.android.com/android-13/#a13-your-phone-your-aesthetic) introduced in Android 13.
I had to remove the shadow in the the VectorDrawable as it interfered with the way Themed icons render.